### PR TITLE
An uniform way to compute a random recipe

### DIFF
--- a/src/main/java/com/google/sps/servlets/QueryForSize.java
+++ b/src/main/java/com/google/sps/servlets/QueryForSize.java
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.KeyRange;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
+public class QueryForSize {
+
+  public int countRecipes() {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query("Recipe").addSort("title", SortDirection.ASCENDING);
+    PreparedQuery preparedQuery = datastore.prepare(query);
+    int lengthOfQuery = preparedQuery.countEntities();
+
+    return lengthOfQuery;
+  }
+}

--- a/src/main/java/com/google/sps/servlets/RandomRecipeServlet.java
+++ b/src/main/java/com/google/sps/servlets/RandomRecipeServlet.java
@@ -20,13 +20,16 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.KeyRange;
 import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.search.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,47 +60,53 @@ public class RandomRecipeServlet extends HttpServlet {
    * This function generates a random double and returns the id of the first Entity with the closest value of "random_number".
    */
   private long returnRandomId(DatastoreService datastore) {
-    Random randomGenerator = new Random();
-    Double numberGenerated = randomGenerator.nextDouble();
-    try {
-      return closestRecipeRandomId(
-        numberGenerated,
-        datastore,
-        Query.FilterOperator.LESS_THAN_OR_EQUAL,
-        Query.SortDirection.DESCENDING
-      );
-    } catch (IndexOutOfBoundsException e) {
-      return closestRecipeRandomId(
-        numberGenerated,
-        datastore,
-        Query.FilterOperator.GREATER_THAN_OR_EQUAL,
-        Query.SortDirection.ASCENDING
-      );
+    int position = getRandomPosition(datastore);
+    Results<ScoredDocument> recipes = getRecipeDocumentFromPosition(
+      datastore,
+      position
+    );
+    for (ScoredDocument recipe : recipes) {
+      return Long.parseLong(recipe.getId());
     }
+    return 0;
   }
 
   /**
-   * Return the recipe's id with the minimum difference between numberGenerated and recipe's random_number.
+   * QueryForSize is a class that returns the number of entities inside the datastore.
+   * This is computed in a different class because the datastore.Query class (used for counting entities)
+   * conflicts with search.Query class (used for searching for a recipe).
    */
-  private long closestRecipeRandomId(
-    Double numberGenerated,
-    DatastoreService datastore,
-    Query.FilterOperator filter,
-    Query.SortDirection direction
-  ) {
-    Filter propertyFilter = new FilterPredicate(
-      "random_number",
-      filter,
-      numberGenerated
-    );
-    Query query = new Query("Recipe")
-      .setFilter(propertyFilter)
-      .addSort("random_number", direction);
+  private int getRandomPosition(DatastoreService datastore) {
+    QueryForSize newQuery = new QueryForSize();
+    int recipesNumber = newQuery.countRecipes();
 
-    PreparedQuery preparedQuery = datastore.prepare(query);
-    List<Entity> recipeEntity = preparedQuery.asList(
-      FetchOptions.Builder.withLimit(1)
-    );
-    return recipeEntity.get(0).getKey().getId();
+    Random randomGenerator = new Random();
+    int randomPosition = randomGenerator.nextInt(recipesNumber);
+
+    return randomPosition;
+  }
+
+  private Results<ScoredDocument> getRecipeDocumentFromPosition(
+    DatastoreService datastore,
+    int position
+  ) {
+    QueryOptions options = QueryOptions
+      .newBuilder()
+      .setLimit(1)
+      .setOffset(position)
+      .build();
+    Query query = Query.newBuilder().setOptions(options).build("");
+    Index index = getIndex("recipes_index");
+
+    return index.search(query);
+  }
+
+  /**
+   * Returns the index that stores the recipes documents
+   */
+  private Index getIndex(String indexName) {
+    IndexSpec indexSpec = IndexSpec.newBuilder().setName(indexName).build();
+    Index index = SearchServiceFactory.getSearchService().getIndex(indexSpec);
+    return index;
   }
 }

--- a/src/main/java/com/google/sps/servlets/RandomRecipeServlet.java
+++ b/src/main/java/com/google/sps/servlets/RandomRecipeServlet.java
@@ -33,6 +33,7 @@ import com.google.appengine.api.search.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Iterator;
 import java.util.Random;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -65,10 +66,9 @@ public class RandomRecipeServlet extends HttpServlet {
       datastore,
       position
     );
-    for (ScoredDocument recipe : recipes) {
-      return Long.parseLong(recipe.getId());
-    }
-    return 0;
+    Iterator iter = recipes.iterator();
+    ScoredDocument document = (ScoredDocument) iter.next();
+    return Long.parseLong(document.getId());
   }
 
   /**

--- a/src/main/webapp/one-off/databaseInit.java
+++ b/src/main/webapp/one-off/databaseInit.java
@@ -188,8 +188,6 @@ public class TestUploadServlet extends HttpServlet {
     Entity recipeEntity = new Entity(keyRange.getStart());
     String description =
       "Lorem quam dolor dapibus ante, sit amet pellentesque turpis lacus eu ipsum. Duis quis mi ut tortor interdum efficitur quis at mi. Pellentesque quis mauris vel ligula commodo scelerisque. In vulputate quam nisl, vel sagittis ipsum molestie quis. Suspendisse quis ipsum a sem aliquam euismod mattis sed metus.";
-    Random rd = new Random();
-    Double number = rd.nextDouble();
     recipeEntity.setProperty("title", title);
     recipeEntity.setProperty("imgURL", imgURL);
     recipeEntity.setProperty("ingredients", ingredients);
@@ -201,7 +199,6 @@ public class TestUploadServlet extends HttpServlet {
     recipeEntity.setProperty("prep_time", prep_time);
     recipeEntity.setProperty("cook_time", "N/A");
     recipeEntity.setProperty("author_id", 1);
-    recipeEntity.setProperty("random_number", number);
 
     return recipeEntity;
   }


### PR DESCRIPTION
The previous method of computing a **random recipe** wasn't uniform because the value assigned to each recipe was random and there may be multiple recipes with the same value. 

- Now, if the user wants a random recipe, the request is sent to the `RandomRecipeServlet.java` which picks a random offset for a recipe. 
- The offset can be chosen only from the interval [0, number of recipes).  
- The servlet redirects to the recipe's details page.
